### PR TITLE
Support ignoring actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,27 @@ new Vuex.Store({
 });
 ```
 
+### Ignoring actions
+
+Occasionally, you may want to perform mutations without including them in the undo history (say you are working on an image editor and the user toggles grid visibility - you probably do not want this in undo history). The plugin has an `ignoredMutations` setting to leave these mutations out of the history:
+
+```js
+Vue.use(VuexUndoRedo, { ignoreMutations: [ 'toggleGrid' ]});
+```
+
+It's worth noting that this only means the mutations will not be recorded in the undo history. You must still manually manage your state object in the `emptyState` mutation:
+
+```js
+emptyState(state) {
+  this.replaceState({ myval: null, showGrid: state.showGrid });       
+}
+```
+
 ## API
+
+### Options
+
+`ignoredMutations` an array of mutations that the plugin will ignore
 
 ### Computed properties
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,18 +1,19 @@
 const EMPTY_STATE = 'emptyState';
 
 module.exports = {
-  install(Vue) {
+  install(Vue, options) {
     Vue.mixin({
       data() {
         return {
           done: [],
           undone: [],
-          newMutation: true
+          newMutation: true,
+          ignoreActions: options.ignoreActions || []
         };
       },
       created() {
         this.$store.subscribe(mutation => {
-          if (mutation.type !== EMPTY_STATE) {
+          if (mutation.type !== EMPTY_STATE && this.ignoreActions.indexOf(mutation.type) === -1) {
             this.done.push(mutation);
           }
           if (this.newMutation) {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,19 +1,19 @@
 const EMPTY_STATE = 'emptyState';
 
 module.exports = {
-  install(Vue, options) {
+  install(Vue, options = {}) {
     Vue.mixin({
       data() {
         return {
           done: [],
           undone: [],
           newMutation: true,
-          ignoreActions: options.ignoreActions || []
+          ignoreMutations: options.ignoreMutations|| []
         };
       },
       created() {
         this.$store.subscribe(mutation => {
-          if (mutation.type !== EMPTY_STATE && this.ignoreActions.indexOf(mutation.type) === -1) {
+          if (mutation.type !== EMPTY_STATE && this.ignoreMutations.indexOf(mutation.type) === -1) {
             this.done.push(mutation);
           }
           if (this.newMutation) {


### PR DESCRIPTION
Simple implementation of ignored actions. Pass `{ ignoreActions: ['someAction'] }` in the plugin options. The ignored actions are simply left out of the undo history.

The part I'm not sure about is EMPTY_STATE. The user of the plugin will have to manually "pass through" the ignored part of the state:

```
  emptyState(state) {
      this.replaceState({ slice1: [], someOtherSlice: state.someOtherSlice });
    },
```

slice1 will be reset and someOtherSlice is assumed to be managed by ignored actions. This is fine to an extent but obviously actions don't map 1:1 to parts of state. 