### PR TITLE
Add support for grouped actions

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,13 +1,14 @@
 const EMPTY_STATE = 'emptyState';
 
 module.exports = {
-  install(Vue) {
+  install(Vue, options) {
     Vue.mixin({
       data() {
         return {
           done: [],
           undone: [],
-          newMutation: true
+          newMutation: true,
+          groupActions: options.groupActions || []
         };
       },
       created() {
@@ -29,14 +30,37 @@ module.exports = {
         }
       },
       methods: {
+        _isGroupedAction(action) {
+          return this.groupActions.indexOf(action.type) !== -1
+        },
+        _redoGrouped(type) {
+          while (this.undone.length > 0 && this.undone[this.undone.length - 1].type === type) {
+            let commit = this.undone.pop();
+            this.$store.commit(`${commit.type}`, Object.assign({}, commit.payload));
+          }
+        },
         redo() {
-          let commit = this.undone.pop();
           this.newMutation = false;
+          let commit = this.undone.pop();
           this.$store.commit(`${commit.type}`, Object.assign({}, commit.payload));
+
+          // If the action is a grouped action, redo the rest
+          if (this._isGroupedAction(commit)) {
+            this._redoGrouped(commit.type)
+          }
+
           this.newMutation = true;
         },
         undo() {
-          this.undone.push(this.done.pop());
+          const commit = this.done.pop()
+          this.undone.push(commit);
+
+          if (this._isGroupedAction(commit)) {
+            while (this.done[this.done.length - 1].type === commit.type) {
+              this.undone.push(this.done.pop())
+            }
+          }
+
           this.newMutation = false;
           this.$store.commit(EMPTY_STATE);
           this.done.forEach(mutation => {


### PR DESCRIPTION
Initial implementation of grouped actions. Usage:

```
  Vue.use(VuexUndoRedo, { groupActions: ['someAction'] });
```

If 'someAction' is commited 15 times in a row and undo() is called, all 15 actions will be undone in one go. Redo works the other way and the entire group is restored.