### PR TITLE
Fix redo/undo bug. Now checks if object is Array before Object.assign

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -40,7 +40,9 @@ module.exports = {
           this.newMutation = false;
           switch (typeof commit.payload) {
             case 'object':
-              this.$store.commit(`${commit.type}`, Object.assign({}, commit.payload));
+              let baseObj = {};
+              if (mutation.payload instanceof Array) { baseObj = [] }
+              this.$store.commit(`${commit.type}`, Object.assign(baseObj, commit.payload));
               break;
             default:
               this.$store.commit(`${commit.type}`, commit.payload);
@@ -54,7 +56,9 @@ module.exports = {
           this.done.forEach(mutation => {
             switch (typeof mutation.payload) {
               case 'object':
-                this.$store.commit(`${mutation.type}`, Object.assign({}, mutation.payload));
+                let baseObj = {};
+                if (mutation.payload instanceof Array) { baseObj = [] }
+                this.$store.commit(`${mutation.type}`, Object.assign(baseObj, mutation.payload));
                 break;
               default:
                 this.$store.commit(`${mutation.type}`, mutation.payload);


### PR DESCRIPTION
Ran into this bug while using the plugin. If a Vuex mutator is called with an Array (e.g. `["a", "b", "c"]`) on undo/redo it will pass in an object with keys of the index (e.g. `{0: "a", 1: "b", 2: "c"}`). This PR fixes that by checking if the object is an Array and if so, it effectively calls `Object.assign([], obj)` instead of `Object.assign({}, obj)`.

Let me know if there are any stylistic compatibility issues I should fix.